### PR TITLE
Don't use reallocarray

### DIFF
--- a/netif/udptapif.c
+++ b/netif/udptapif.c
@@ -210,7 +210,7 @@ udptapif_ready(evutil_socket_t fd, short events, void *ctx, int raw)
 			if (free == -1) {
 				free = client->n;
 				client->n *= 2;
-				client->hw = reallocarray(client->hw, client->n, sizeof(*client->hw));
+				client->hw = realloc(client->hw, client->n * sizeof(*client->hw));
 				memset(client->hw + free, 0, sizeof(*client->hw) * free);
 			}
 			client->hw[free].addr = hdr->src;

--- a/netif/vdeswitchif.c
+++ b/netif/vdeswitchif.c
@@ -234,7 +234,7 @@ vdeswitchif_ready(evutil_socket_t fd, short events, void *ctx)
 		if (free == -1) {
 			free = client->n;
 			client->n *= 2;
-			client->hw = reallocarray(client->hw, client->n, sizeof(*client->hw));
+			client->hw = realloc(client->hw, client->n * sizeof(*client->hw));
 			memset(client->hw + free, 0, sizeof(*client->hw) * free);
 		}
 		client->hw[free].addr = hdr->src;


### PR DESCRIPTION
reallocarray is a non-standard function, since it can easily be replaced
with the standard function realloc use that instead. This fixes
compilation of tunsocks on musl libc based systems.